### PR TITLE
Some CMakeLists.txt cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,15 +278,6 @@ set(LIBUTIL_SOURCE_FILES
         libutil/Timecode.cpp)
 
 #
-# Set include folders
-#
-include_directories(
-   ${CMAKE_BINARY_DIR}
-   ${CMAKE_BINARY_DIR}/include
-   ${CMAKE_SOURCE_DIR}
-   ${CMAKE_SOURCE_DIR}/include)
-
-#
 # Define library targets
 #
 if(BUILD_SHARED)
@@ -296,6 +287,15 @@ if(BUILD_SHARED)
 else()
     add_library(mp4v2 STATIC ${MP4V2_PUBLIC_HEADERS} ${MP4V2_PRIVATE_HEADERS} ${MP4V2_SOURCE_FILES})
 endif()
+
+#
+# Set include folders
+#
+target_include_directories(mp4v2 PRIVATE
+   ${CMAKE_BINARY_DIR}
+   ${CMAKE_BINARY_DIR}/include
+   ${CMAKE_SOURCE_DIR}
+   ${CMAKE_SOURCE_DIR}/include)
 
 #
 # Define utilities targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,9 +293,7 @@ endif()
 #
 target_include_directories(mp4v2 PUBLIC
    ${CMAKE_CURRENT_BINARY_DIR}/include
-   ${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-target_include_directories(mp4v2 PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}/include
    ${CMAKE_CURRENT_BINARY_DIR}
    ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -307,6 +305,7 @@ if(BUILD_UTILS)
        util/impl.h)
 
     add_library(util STATIC ${LIBUTIL_HEADER_FILES} ${LIBUTIL_SOURCE_FILES})
+    target_link_libraries(util mp4v2)
 
     add_executable(mp4art ${UTILITY_HEADER_FILES} util/mp4art.cpp)
     target_link_libraries(mp4art mp4v2 util)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,12 +292,12 @@ endif()
 # Set include folders
 #
 target_include_directories(mp4v2 PUBLIC
-   ${CMAKE_BINARY_DIR}/include
-   ${CMAKE_SOURCE_DIR}/include)
+   ${CMAKE_CURRENT_BINARY_DIR}/include
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_include_directories(mp4v2 PRIVATE
-   ${CMAKE_BINARY_DIR}
-   ${CMAKE_SOURCE_DIR})
+   ${CMAKE_CURRENT_BINARY_DIR}
+   ${CMAKE_CURRENT_SOURCE_DIR})
 
 #
 # Define utilities targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,11 +291,13 @@ endif()
 #
 # Set include folders
 #
+target_include_directories(mp4v2 PUBLIC
+   ${CMAKE_BINARY_DIR}/include
+   ${CMAKE_SOURCE_DIR}/include)
+
 target_include_directories(mp4v2 PRIVATE
    ${CMAKE_BINARY_DIR}
-   ${CMAKE_BINARY_DIR}/include
-   ${CMAKE_SOURCE_DIR}
-   ${CMAKE_SOURCE_DIR}/include)
+   ${CMAKE_SOURCE_DIR})
 
 #
 # Define utilities targets


### PR DESCRIPTION
This PR makes a few improvements to the CMakeLists.txt to make it work in our dev environment. We have mp4v2 as a submodule and use `add_subdirectory(mp4v2)` to make mp4v2 available to our CMake-based build system.

1. Use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`, since our `CMAKE_SOURCE_DIR` isn't actually the mp4v2 folder. Added a similar change for `CMAKE_BINARY_DIR`.
2. Switched to `target_include_directories`, instead of using the global `include_directories`, which affects all targets. We have many targets in our CMake build system that this would also affect.
3. Adding PUBLIC and PRIVATE to the `target_include_directories`, which allows our CMakeLists to simply `target_link_libraries(target PRIVATE mp4v2)` and have CMake automatically add the correct include directories for mp4v2.