### PR TITLE
Add 'lpcm' and 'ipcm' audio atoms

### DIFF
--- a/src/atom_sound.cpp
+++ b/src/atom_sound.cpp
@@ -37,17 +37,6 @@ MP4SoundAtom::MP4SoundAtom(MP4File &file, const char *atomid)
         new MP4Integer16Property(*this, "soundVersion"));
     AddReserved( *this, "reserved2", 6); /* 3 */
 
-    AddProperty( /* 4 */
-        new MP4Integer16Property(*this, "channels"));
-    AddProperty( /* 5 */
-        new MP4Integer16Property(*this, "sampleSize"));
-    AddProperty( /* 6 */
-        new MP4Integer16Property(*this, "compressionId"));
-    AddProperty( /* 7 */
-        new MP4Integer16Property(*this, "packetSize"));
-    AddProperty( /* 8 */
-        new MP4Integer32Property(*this, "timeScale"));
-
     if (ATOMID(atomid) == ATOMID("mp4a")) {
         ExpectChildAtom("esds", Required, OnlyOne);
         ExpectChildAtom("wave", Optional, OnlyOne);
@@ -59,7 +48,19 @@ MP4SoundAtom::MP4SoundAtom(MP4File &file, const char *atomid)
 
 void MP4SoundAtom::AddProperties (uint8_t version)
 {
-    if (version > 0) {
+    if (version < 2) {
+        AddProperty( /* 4 */
+            new MP4Integer16Property(*this, "channels"));
+        AddProperty( /* 5 */
+            new MP4Integer16Property(*this, "sampleSize"));
+        AddProperty( /* 6 */
+            new MP4Integer16Property(*this, "compressionId"));
+        AddProperty( /* 7 */
+            new MP4Integer16Property(*this, "packetSize"));
+        AddProperty( /* 8 */
+            new MP4Integer32Property(*this, "timeScale"));
+    }
+    if (version == 1) {
         AddProperty( /* 9 */
             new MP4Integer32Property(*this, "samplesPerPacket"));
         AddProperty( /* 10 */
@@ -70,15 +71,44 @@ void MP4SoundAtom::AddProperties (uint8_t version)
             new MP4Integer32Property(*this, "bytesPerSample"));
     }
     if (version == 2) {
-        AddReserved(*this, "reserved4", 20);
+        AddProperty( /* 4 */
+            new MP4Integer16Property(*this, "always3"));
+        AddProperty( /* 5 */
+            new MP4Integer16Property(*this, "always16"));
+        AddProperty( /* 6 */
+            new MP4Integer16Property(*this, "alwaysMinus2"));
+        AddProperty( /* 7 */
+            new MP4Integer16Property(*this, "always0"));
+        AddProperty( /* 8 */
+            new MP4Integer32Property(*this, "always65536"));
+        AddProperty( /* 9 */
+            new MP4Integer32Property(*this, "sizeOfStructOnly"));
+        AddProperty( /* 10 */
+            new MP4Float64Property(*this, "timeScale"));
+        AddProperty( /* 11 */
+            new MP4Integer32Property(*this, "channels")); //numAudioChannels
+        AddProperty( /* 12 */
+            new MP4Integer32Property(*this, "always7F000000"));
+        AddProperty( /* 13 */
+            new MP4Integer32Property(*this, "constBitsPerChannel"));
+        AddProperty( /* 14 */
+            new MP4Integer32Property(*this, "formatSpecificFlags"));
+        AddProperty( /* 15 */
+            new MP4Integer32Property(*this, "constBytesPerAudioPacket"));
+        AddProperty( /* 16 */
+            new MP4Integer32Property(*this, "constLPCMFramesPerAudioPacket"));
     }
 }
 void MP4SoundAtom::Generate()
 {
+    const uint8_t Version = ATOMID(GetType()) == ATOMID("lpcm") ? 2 : 0;
+
     MP4Atom::Generate();
 
     ((MP4Integer16Property*)m_pProperties[1])->SetValue(1);
-    ((MP4Integer16Property*)m_pProperties[2])->SetValue(0);
+    ((MP4Integer16Property*)m_pProperties[2])->SetValue(Version);
+
+    AddProperties(Version);
 
     // property reserved2 has non-zero fixed values
     static const uint8_t reserved2[6] = {
@@ -86,13 +116,24 @@ void MP4SoundAtom::Generate()
         0x00, 0x00,
     };
     m_pProperties[3]->SetReadOnly(false);
-    ((MP4BytesProperty*)m_pProperties[3])->
-    SetValue(reserved2, sizeof(reserved2));
+    ((MP4BytesProperty*)m_pProperties[3])->SetValue(reserved2,
+                                                    sizeof(reserved2));
     m_pProperties[3]->SetReadOnly(true);
-    ((MP4Integer16Property*)m_pProperties[4])->SetValue(2);
-    ((MP4Integer16Property*)m_pProperties[5])->SetValue(0x0010);
-    ((MP4Integer16Property*)m_pProperties[6])->SetValue(0);
 
+    if (Version < 2) {
+        ((MP4Integer16Property*)m_pProperties[4])->SetValue(2);
+        ((MP4Integer16Property*)m_pProperties[5])->SetValue(0x0010);
+        ((MP4Integer16Property*)m_pProperties[6])->SetValue(0);
+    } else {
+        ((MP4Integer16Property*)m_pProperties[4])->SetValue(3);
+        ((MP4Integer16Property*)m_pProperties[5])->SetValue(16);
+        ((MP4Integer16Property*)m_pProperties[6])->SetValue(0xFFFE);
+        ((MP4Integer16Property*)m_pProperties[7])->SetValue(0);
+        ((MP4Integer32Property*)m_pProperties[8])->SetValue(65536);
+        ((MP4Integer32Property*)m_pProperties[9])->SetValue(72);
+        ((MP4Integer32Property*)m_pProperties[12])->SetValue(0x7F000000);
+        ((MP4Integer32Property*)m_pProperties[16])->SetValue(1);
+    }
 }
 
 void MP4SoundAtom::Read()
@@ -102,18 +143,12 @@ void MP4SoundAtom::Read()
         // Quicktime has an interesting thing - they'll put an mp4a atom
         // which is blank inside a wave atom, which is inside an mp4a atom
         // we have a mp4a inside an wave inside an mp4a - delete all properties
-        for(int i = 0; i < 9; ++ i)
+        MP4ArrayIndex propCnt = m_pProperties.Size();
+        for(MP4ArrayIndex i = 0; i < propCnt; ++i)
             delete m_pProperties[i];	// make sure we delete the properties themselves, then remove from  m_pProperties
 
-        m_pProperties.Delete(8);
-        m_pProperties.Delete(7);
-        m_pProperties.Delete(6);
-        m_pProperties.Delete(5);
-        m_pProperties.Delete(4);
-        m_pProperties.Delete(3);
-        m_pProperties.Delete(2);
-        m_pProperties.Delete(1);
-        m_pProperties.Delete(0);
+        while (propCnt--)
+            m_pProperties.Delete(propCnt);
 
         if (ATOMID(GetType()) == ATOMID("alac")) {
             AddProperty(new MP4BytesProperty(*this, "decoderConfig", m_size));

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -899,11 +899,18 @@ MP4Atom::factory( MP4File &file, MP4Atom* parent, const char* type )
                 return new MP4TrefTypeAtom( file, type );
             if( ATOMID(type) == ATOMID("ima4") )
                 return new MP4SoundAtom( file, type );
+            if( ATOMID(type) == ATOMID("ipcm") )
+                return new MP4SoundAtom( file, type );
             break;
 
         case 'j':
             if( ATOMID(type) == ATOMID("jpeg") )
                 return new MP4VideoAtom(file, "jpeg");
+            break;
+
+        case 'l':
+            if( ATOMID(type) == ATOMID("lpcm") )
+                return new MP4SoundAtom( file, type );
             break;
 
         case 'm':

--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -881,6 +881,21 @@ void MP4File::FindFloatProperty(const char* name,
     }
 }
 
+void MP4File::FindDoubleProperty(const char* name,
+                                 MP4Property** ppProperty, uint32_t* pIndex)
+{
+    if (!FindProperty(name, ppProperty, pIndex)) {
+        ostringstream msg;
+        msg << "no such property - " << name;
+        throw new EXCEPTION(msg.str());
+    }
+    if ((*ppProperty)->GetType() != Float64Property) {
+        ostringstream msg;
+        msg << "type mismatch - property " << name << " type " << (*ppProperty)->GetType();
+        throw new EXCEPTION(msg.str());
+    }
+}
+
 float MP4File::GetFloatProperty(const char* name)
 {
     MP4Property* pProperty;
@@ -889,6 +904,16 @@ float MP4File::GetFloatProperty(const char* name)
     FindFloatProperty(name, &pProperty, &index);
 
     return ((MP4Float32Property*)pProperty)->GetValue(index);
+}
+
+double MP4File::GetDoubleProperty(const char* name)
+{
+    MP4Property* pProperty;
+    uint32_t index;
+
+    FindDoubleProperty(name, &pProperty, &index);
+
+    return ((MP4Float64Property*)pProperty)->GetValue(index);
 }
 
 void MP4File::SetFloatProperty(const char* name, float value)
@@ -901,6 +926,18 @@ void MP4File::SetFloatProperty(const char* name, float value)
     FindFloatProperty(name, &pProperty, &index);
 
     ((MP4Float32Property*)pProperty)->SetValue(value, index);
+}
+
+void MP4File::SetDoubleProperty(const char* name, double value)
+{
+    PROTECT_WRITE_OPERATION();
+
+    MP4Property* pProperty;
+    uint32_t index;
+
+    FindDoubleProperty(name, &pProperty, &index);
+
+    ((MP4Float64Property*)pProperty)->SetValue(value, index);
 }
 
 void MP4File::FindStringProperty(const char* name,
@@ -3190,6 +3227,12 @@ void MP4File::SetTrackFloatProperty(MP4TrackId trackId, const char* name,
                                     float value)
 {
     SetFloatProperty(MakeTrackName(trackId, name), value);
+}
+
+void MP4File::SetTrackDoubleProperty(MP4TrackId trackId, const char* name,
+                                     double value)
+{
+    SetDoubleProperty(MakeTrackName(trackId, name), value);
 }
 
 const char* MP4File::GetTrackStringProperty(MP4TrackId trackId, const char* name)

--- a/src/mp4file.h
+++ b/src/mp4file.h
@@ -104,12 +104,14 @@ public:
 
     uint64_t GetIntegerProperty(const char* name);
     float GetFloatProperty(const char* name);
+    double GetDoubleProperty(const char* name);
     const char* GetStringProperty(const char* name);
     void GetBytesProperty(const char* name,
                           uint8_t** ppValue, uint32_t* pValueSize);
 
     void SetIntegerProperty(const char* name, uint64_t value);
     void SetFloatProperty(const char* name, float value);
+    void SetDoubleProperty(const char* name, double value);
     void SetStringProperty(const char* name, const char* value);
     void SetBytesProperty(const char* name,
                           const uint8_t* pValue, uint32_t valueSize);
@@ -160,6 +162,8 @@ public:
         MP4TrackId trackId, const char* name);
     float GetTrackFloatProperty(
         MP4TrackId trackId, const char* name);
+    double GetTrackDoubleProperty(
+        MP4TrackId trackId, const char* name);
     const char* GetTrackStringProperty(
         MP4TrackId trackId, const char* name);
     void GetTrackBytesProperty(
@@ -170,6 +174,8 @@ public:
         MP4TrackId trackId, const char* name, int64_t value);
     void SetTrackFloatProperty(
         MP4TrackId trackId, const char* name, float value);
+    void SetTrackDoubleProperty(
+        MP4TrackId trackId, const char* name, double value);
     void SetTrackStringProperty(
         MP4TrackId trackId, const char* name, const char* value);
     void SetTrackBytesProperty(
@@ -788,6 +794,7 @@ public:
     float ReadFixed16();
     float ReadFixed32();
     float ReadFloat();
+    double ReadDouble();
     char* ReadString();
     char* ReadCountedString(uint8_t charSize = 1,
                             bool allowExpandedCount = false,
@@ -809,6 +816,7 @@ public:
     void WriteFixed16(float value);
     void WriteFixed32(float value);
     void WriteFloat(float value);
+    void WriteDouble(double value);
     void WriteString(char* string);
     void WriteCountedString(char* string,
                             uint8_t charSize = 1,
@@ -881,6 +889,8 @@ protected:
                              MP4Property** ppProperty, uint32_t* pIndex = NULL);
     void FindFloatProperty(const char* name,
                            MP4Property** ppProperty, uint32_t* pIndex = NULL);
+    void FindDoubleProperty(const char* name,
+                            MP4Property** ppProperty, uint32_t* pIndex = NULL);
     void FindStringProperty(const char* name,
                             MP4Property** ppProperty, uint32_t* pIndex = NULL);
     void FindBytesProperty(const char* name,

--- a/src/mp4file_io.cpp
+++ b/src/mp4file_io.cpp
@@ -310,6 +310,17 @@ float MP4File::ReadFloat()
     return u.f;
 }
 
+double MP4File::ReadDouble()
+{
+    union {
+        double f;
+        uint64_t i;
+    } u;
+
+    u.i = ReadUInt64();
+    return u.f;
+}
+
 void MP4File::WriteFloat(float value)
 {
     union {
@@ -319,6 +330,17 @@ void MP4File::WriteFloat(float value)
 
     u.f = value;
     WriteUInt32(u.i);
+}
+
+void MP4File::WriteDouble(double value)
+{
+    union {
+        double f;
+        uint64_t i;
+    } u;
+
+    u.f = value;
+    WriteUInt64(u.i);
 }
 
 char* MP4File::ReadString()

--- a/src/mp4property.cpp
+++ b/src/mp4property.cpp
@@ -311,6 +311,42 @@ void MP4Float32Property::Dump(uint8_t indent,
                  m_name, m_values[index]);
 }
 
+// MP4Float64Property
+
+void MP4Float64Property::Read(MP4File& file, uint32_t index)
+{
+    if (m_implicit) {
+        return;
+    }
+
+    m_values[index] = file.ReadDouble();
+}
+
+void MP4Float64Property::Write(MP4File& file, uint32_t index)
+{
+    if (m_implicit) {
+        return;
+    }
+
+    file.WriteDouble(m_values[index]);
+}
+
+void MP4Float64Property::Dump(uint8_t indent,
+                              bool dumpImplicits, uint32_t index)
+{
+    if (m_implicit && !dumpImplicits) {
+        return;
+    }
+    if (index != 0)
+        log.dump(indent, MP4_LOG_VERBOSE1, "\"%s\": %s[%u] = %f",
+                 m_parentAtom.GetFile().GetFilename().c_str(),
+                 m_name, index, m_values[index]);
+    else
+        log.dump(indent, MP4_LOG_VERBOSE1, "\"%s\": %s = %f",
+                 m_parentAtom.GetFile().GetFilename().c_str(),
+                 m_name, m_values[index]);
+}
+
 // MP4StringProperty
 
 MP4StringProperty::MP4StringProperty(

--- a/src/mp4property.h
+++ b/src/mp4property.h
@@ -39,6 +39,7 @@ enum MP4PropertyType {
     Integer32Property,
     Integer64Property,
     Float32Property,
+    Float64Property,
     StringProperty,
     BytesProperty,
     TableProperty,
@@ -318,6 +319,60 @@ private:
     MP4Float32Property();
     MP4Float32Property ( const MP4Float32Property &src );
     MP4Float32Property &operator= ( const MP4Float32Property &src );
+};
+
+class MP4Float64Property : public MP4Property {
+public:
+    MP4Float64Property(MP4Atom& parentAtom, const char* name)
+            : MP4Property(parentAtom, name) {
+        SetCount(1);
+        m_values[0] = 0.0;
+    }
+
+    MP4PropertyType GetType() {
+        return Float64Property;
+    }
+
+    uint32_t GetCount() {
+        return m_values.Size();
+    }
+    void SetCount(uint32_t count) {
+        m_values.Resize(count);
+    }
+
+    double GetValue(uint32_t index = 0) {
+        return m_values[index];
+    }
+
+    void SetValue(double value, uint32_t index = 0) {
+        if (m_readOnly) {
+            ostringstream msg;
+            msg << "property is read-only: " << m_name;
+            throw new PlatformException(msg.str().c_str(), EACCES, __FILE__, __LINE__, __FUNCTION__);
+        }
+        m_values[index] = value;
+    }
+
+    void AddValue(double value) {
+        m_values.Add(value);
+    }
+
+    void InsertValue(double value, uint32_t index) {
+        m_values.Insert(value, index);
+    }
+
+    void Read(MP4File& file, uint32_t index = 0);
+    void Write(MP4File& file, uint32_t index = 0);
+    void Dump(uint8_t indent,
+              bool dumpImplicits, uint32_t index = 0);
+
+protected:
+    MP4Float64Array m_values;
+
+private:
+    MP4Float64Property();
+    MP4Float64Property ( const MP4Float64Property &src );
+    MP4Float64Property &operator= ( const MP4Float64Property &src );
 };
 
 class MP4StringProperty : public MP4Property {


### PR DESCRIPTION
Add support for 'lpcm' and 'ipcm' audio atoms that are used by Quick Take iPhone feature. Depending on device model some use the 'lpcm' tag with version 2 audio box, others use 'ipcm' with version 0 audio box.