### PR TITLE
src/atom_free.cpp: fix ambiguous call

### DIFF
--- a/src/atom_free.cpp
+++ b/src/atom_free.cpp
@@ -43,7 +43,7 @@ void MP4FreeAtom::Write()
 
     static uint8_t freebuf[1024];
     for (uint64_t ix = 0; ix < GetSize(); ix += sizeof(freebuf)) {
-        m_File.WriteBytes(freebuf, min(GetSize() - ix, sizeof(freebuf)));
+        m_File.WriteBytes(freebuf, min(GetSize() - ix, (uint64_t)sizeof(freebuf)));
     }
 
     FinishWrite(use64);


### PR DESCRIPTION
Fix the following build failure raised since https://github.com/enzo1982/mp4v2/commit/ec9273405e40c5dc3d33e2b45db5ee9ae89174a3:

```
src/atom_free.cpp: In member function 'virtual void mp4v2::impl::MP4FreeAtom::Write()':
src/atom_free.cpp:46:71: error: call of overloaded 'min(uint64_t, unsigned int)' is ambiguous
         m_File.WriteBytes(freebuf, min(GetSize() - ix, sizeof(freebuf)));
                                                                       ^
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>