### PR TITLE
Make build reproducible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,8 @@ PROJECT_version_major="PRJ_version_major"
 PROJECT_version_minor="PRJ_version_minor"
 PROJECT_version_point="PRJ_version_point"
 PROJECT_repo_url="PRJ_repo_url"
-PROJECT_build="`date`"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+PROJECT_build=$(date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" 2>/dev/null || date -u)
 
 test -z "$PROJECT_version_hex"   && PROJECT_version_hex="0x0000000000000000LL"
 test -z "$PROJECT_version_major" && PROJECT_version_major="0"


### PR DESCRIPTION
Use SOURCE_DATE_EPOCH to create reproducible build date, for CMake no changes are required since 3.8.0 it supports SOURCE_DATE_EPOCH.

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>