### PR TITLE
Fix some cmake-related warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,11 +299,11 @@ set(LIBUTIL_SOURCE_FILES
 # Define library targets
 #
 if(BUILD_SHARED)
-    add_library(mp4v2 SHARED ${MP4V2_PUBLIC_HEADERS} ${MP4V2_PRIVATE_HEADERS} ${MP4V2_SOURCE_FILES})
+    add_library(mp4v2 SHARED ${MP4V2_SOURCE_FILES})
     target_compile_definitions(mp4v2 PRIVATE MP4V2_EXPORTS)
     set_target_properties(mp4v2 PROPERTIES VERSION ${PROJECT_version} SOVERSION ${PROJECT_version_major})
 else()
-    add_library(mp4v2 STATIC ${MP4V2_PUBLIC_HEADERS} ${MP4V2_PRIVATE_HEADERS} ${MP4V2_SOURCE_FILES})
+    add_library(mp4v2 STATIC ${MP4V2_SOURCE_FILES})
     target_compile_definitions(mp4v2 PUBLIC MP4V2_USE_STATIC_LIB)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ configure_pkg_config_file(mp4v2.pc.in)
 # Define MP4v2 source files
 #
 set(MP4V2_PUBLIC_HEADERS
+        ${CMAKE_BINARY_DIR}/include/mp4v2/project.h
         include/mp4v2/chapter.h
         include/mp4v2/file.h
         include/mp4v2/file_prop.h
@@ -108,20 +109,19 @@ set(MP4V2_PUBLIC_HEADERS
         include/mp4v2/itmf_tags.h
         include/mp4v2/mp4v2.h
         include/mp4v2/platform.h
-        include/mp4v2/project.h
         include/mp4v2/sample.h
         include/mp4v2/streaming.h
         include/mp4v2/track.h
         include/mp4v2/track_prop.h)
 
 set(MP4V2_PRIVATE_HEADERS
+        ${CMAKE_BINARY_DIR}/libplatform/config.h
         libplatform/io/File.h
         libplatform/io/FileSystem.h
         libplatform/number/random.h
         libplatform/prog/option.h
         libplatform/sys/error.h
         libplatform/time/time.h
-        libplatform/config.h
         libplatform/endian.h
         libplatform/impl.h
         libplatform/platform.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ set(MP4V2_PUBLIC_HEADERS
         include/mp4v2/track_prop.h)
 
 set(MP4V2_PRIVATE_HEADERS
-        libplatform/io/File.cpp
         libplatform/io/File.h
         libplatform/io/FileSystem.h
         libplatform/number/random.h
@@ -190,6 +189,7 @@ endif()
 
 set(MP4V2_SOURCE_FILES
         ${MP4V2_OSSPEC_SRC}
+        libplatform/io/File.cpp
         libplatform/io/FileSystem.cpp
         libplatform/prog/option.cpp
         libplatform/sys/error.cpp


### PR DESCRIPTION
There are two cmake-related problems:

- The list of headers contains a source file
- Headers are added as library dependencies

This commit fixes both of them.