### PR TITLE
fix illegal array index when IsSyncSample() m_pStssCountProperty->GetValue() == 0

### DIFF
--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -1377,6 +1377,10 @@ bool MP4Track::IsSyncSample(MP4SampleId sampleId)
     }
 
     uint32_t numStss = m_pStssCountProperty->GetValue();
+    if (numStss == 0) {
+        return false;
+    }
+
     uint32_t stssLIndex = 0;
     uint32_t stssRIndex = numStss - 1;
 


### PR DESCRIPTION
When numStss is zero on IsSyncSample(), an illegal array index is triggered.