### PR TITLE
Don't build/install mp4subtitle by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 option(BUILD_SHARED "Build libmp4v2 as a shared library" ON)
 option(BUILD_UTILS "Build MP4v2 auxiliary tools" ON)
+option(BUILD_EXTRA_UTILS "Build MP4v2 tools with unimplemented functionality" OFF)
 
 #
 # Generate include/mp4v2/project.h and libplatform/config.h
@@ -91,7 +92,7 @@ function(configure_pkg_config_file pkg_config_file_in)
     set(VERSION ${PROJECT_version})
     string(REPLACE ".in" "" pkg_config_file ${pkg_config_file_in})
     configure_file(${pkg_config_file_in} ${pkg_config_file} @ONLY)
-endfunction() 
+endfunction()
 
 configure_pkg_config_file(mp4v2.pc.in)
 
@@ -348,9 +349,6 @@ if(BUILD_UTILS)
     add_executable(mp4info ${UTILITY_HEADER_FILES} util/mp4info.cpp)
     target_link_libraries(mp4info mp4v2)
 
-    add_executable(mp4subtitle ${UTILITY_HEADER_FILES} util/mp4subtitle.cpp)
-    target_link_libraries(mp4subtitle mp4v2)
-
     add_executable(mp4tags ${UTILITY_HEADER_FILES} util/mp4tags.cpp)
     target_link_libraries(mp4tags mp4v2)
 
@@ -359,6 +357,12 @@ if(BUILD_UTILS)
 
     add_executable(mp4trackdump ${UTILITY_HEADER_FILES} util/mp4trackdump.cpp)
     target_link_libraries(mp4trackdump mp4v2)
+
+    if (BUILD_EXTRA_UTILS)
+        add_executable(mp4subtitle ${UTILITY_HEADER_FILES} util/mp4subtitle.cpp)
+        target_link_libraries(mp4subtitle mp4v2)
+    endif()
+
 endif()
 
 #
@@ -381,14 +385,21 @@ endif()
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mp4v2.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 if(BUILD_UTILS)
-    install(TARGETS mp4art
-                    mp4chaps
-                    mp4extract
-                    mp4file
-                    mp4info
-                    mp4subtitle
-                    mp4tags
-                    mp4track
-                    mp4trackdump RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    set(_util_targets
+        mp4art
+        mp4chaps
+        mp4extract
+        mp4file
+        mp4info
+        mp4tags
+        mp4track
+        mp4trackdump
+    )
+    if(BUILD_EXTRA_UTILS)
+        list(APPEND _util_targets
+            mp4subtitle
+        )
+    endif()
+    install(TARGETS ${_util_targets}
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
-

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -200,10 +200,13 @@ if ADD_UTIL
     bin_PROGRAMS += mp4extract
     bin_PROGRAMS += mp4file
     bin_PROGRAMS += mp4info
-    bin_PROGRAMS += mp4subtitle
     bin_PROGRAMS += mp4tags
     bin_PROGRAMS += mp4track
     bin_PROGRAMS += mp4trackdump
+endif
+
+if ADD_EXTRA_UTIL
+    bin_PROGRAMS += mp4subtitle
 endif
 
 mp4art_SOURCES       = util/impl.h util/mp4art.cpp
@@ -298,16 +301,22 @@ MK_CXX_I = \
 
 ###############################################################################
 
-if ADD_UTIL
 if ADD_MANS
-    man1_MANS = \
+man1_MANS =
+
+if ADD_UTIL
+    man1_MANS += \
         doc/man/man1/mp4art.1       \
         doc/man/man1/mp4chaps.1     \
         doc/man/man1/mp4file.1      \
-        doc/man/man1/mp4subtitle.1  \
         doc/man/man1/mp4tags.1      \
         doc/man/man1/mp4track.1
 endif
+
+if ADD_EXTRA_UTIL
+    man1_MANS += doc/man/man1/mp4subtitle.1
+endif
+
 endif
 
 ###############################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,8 @@ AC_ARG_ENABLE([largefile],
     [AS_HELP_STRING([--disable-largefile],[disable LFS (large file support)])])
 AC_ARG_ENABLE([util],
     [AS_HELP_STRING([--disable-util],[disable build of command-line utilities])])
+AC_ARG_ENABLE([extra-util],
+    [AS_HELP_STRING([--enable-extra-util],[enable build of utilities with unimplemented functionality])])
 AC_ARG_ENABLE([gch],
     [AS_HELP_STRING([--enable-gch],[enable use of precompiled headers])])
 AC_ARG_ENABLE([bi],
@@ -355,6 +357,7 @@ AM_CONDITIONAL([ADD_PLATFORM_POSIX],[test "$X_PLATFORM" = "posix"])
 AM_CONDITIONAL([ADD_PLATFORM_WIN32],[test "$X_PLATFORM" = "win32"])
 
 AM_CONDITIONAL([ADD_UTIL],[test "$enable_util" != "no"])
+AM_CONDITIONAL([ADD_EXTRA_UTIL],[test "$enable_extra_util" = "yes"])
 AM_CONDITIONAL([ADD_MANS],[test "$X_PLATFORM" != "win32"])
 
 ###############################################################################


### PR DESCRIPTION
The `mp4subtitle` util has no usable functionality, with all of its features printing "NOT IMPLEMENTED" when activated. So, hide it behind a configuration flag:
  * `-DBUILD_EXTRA_UTILS=1` (CMake)
  * `--enable-extra-util` (autotools) 
 
And default to not building/installing unless set.

The autotools build will also avoid installing the `mp4subtitle.1` man page unless the utility is built.

#### Caveats

The CMake install (silently) makes `BUILD_EXTRA_UTILS` depend on `BUILD_UTILS` — `cmake -DBUILD_UTILS=0 -DBUILD_EXTRA_UTILS=1` will still not build/install `mp4subtitle`.

In the autotools build, technically `configure --disable-util --enable-extra-util` will be accepted, but it will lead to a bad build because `libmp4v2_la_SOURCES` and `libutil_la_SOURCES` won't  be configured with the utility source files.

If either/both is a major concern, checks for bad combinations of flags can be added.
